### PR TITLE
Add repo links to project titles

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -67,6 +67,10 @@ h1 {
 	font-weight: 700;
 }
 
+.montserrat-bold-uppercase .project-link {
+    font-weight: 700;
+}
+
 .hack-logo {
 	width: auto;
 	height: 50px;

--- a/index.html
+++ b/index.html
@@ -73,7 +73,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">HELPq</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/ehzhang/helpq">HELPq</a>
+                </h3>
                 <h4>An extensible, customizable real-time queue system</h4>
                 <p>HELPq was originally built for HackMIT, but has been used at hackathons like Blueprint, Meteor Summer Hackathon 2015, WHACK, MakeMIT and WildHacks (among others!).</p>
                 <p>It is a real-time help queue and mentor management application, targeted at hackathons and classrooms, where there is a need for issues to be claimed and satisfied within minutes. It includes a simple interface for requesting tickets, claiming tickets, administrating users/mentors, and examining metrics.</p>
@@ -128,7 +130,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">Gavel</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/anishathalye/gavel">Gavel</a>
+                </h3>
                 <h4>A project expo judging system</h4>
                 <p>Gavel is the judging system used at HackMIT. It incorporates a lot of research on behavioral economics along with fancy math to produce very fair judging results. It's capable of scaling to large events, being used at HackMIT's 1000-person hackathon.</p>
                 <a class="project-link" href="https://github.com/anishathalye/gavel">View Project</a>
@@ -144,7 +148,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">OffiX</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/anishathalye/offix">OffiX</a>
+                </h3>
                 <h4>"Who is in the office?"</h4>
                 <p>A WiFi-based presence sharing system for specific physical spaces.</p>
                 <a class="project-link" href="https://github.com/anishathalye/offix">View Project</a>
@@ -160,7 +166,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">Redisred</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/Detry322/redisred">Redisred</a>
+                </h3>
                 <h4>A small Redis-based URL redirector</h4>
                 <p>Redisred is a small Redis-based URL redirector with great Slack integration!</p>
                 <a class="project-link" href="https://github.com/Detry322/redisred">View Project</a>
@@ -176,7 +184,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">hubot-redisred</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/Detry322/hubot-redisred">hubot-redisred</a>
+                </h3>
                 <h4>A Hubot plugin for Redisred</h4>
                 <p>hubot-redisred is the most convenient way to use Redisred.</p>
                 <a class="project-link" href="https://github.com/Detry322/hubot-redisred">View Project</a>
@@ -192,7 +202,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">hubot-group</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/anishathalye/hubot-group">hubot-group</a>
+                </h3>
                 <h4>A Hubot plugin that expands mentions of groups</h4>
                 <p>hubot-group lets you easily @mention groups of people.</p>
                 <a class="project-link" href="https://github.com/anishathalye/hubot-group">View Project</a>
@@ -209,7 +221,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">hubot-conf</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/anishathalye/hubot-conf">hubot-conf</a>
+                </h3>
                 <h4>A configuration management system for Hubot</h4>
                 <p>hubot-conf is a two-part configuration management system for Hubot. It can be used by Hubot script implementors to read configuration values. It can also be used by Hubot users to be able to dynamically set (or override) configuration values through the chat interface.</p>
                 <a class="project-link" href="https://github.com/anishathalye/hubot-conf">View Project</a>
@@ -225,7 +239,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">hubot-shortcut</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/anishathalye/hubot-shortcut">hubot-shortcut</a>
+                </h3>
                 <h4>A macro system for Hubot</h4>
                 <p>hubot-shortcut lets you create !shortcuts for your Hubot commands.</p>
                 <a class="project-link" href="https://github.com/anishathalye/hubot-shortcut">View Project</a>
@@ -241,7 +257,9 @@
                 </a>
             </div>
             <div class="col-md-5">
-                <h3 class="montserrat-bold-uppercase">hackmit.org</h3>
+                <h3 class="montserrat-bold-uppercase">
+                    <a class="project-link" href="https://github.com/techx/hackmit-splash">hackmit.org</a>
+                </h3>
                 <h4>The HackMIT splash site</h4>
                 <p>The HackMIT homepage, released under a CC BY-SA license.</p>
                 <a class="project-link" href="https://github.com/techx/hackmit-splash">View Project</a>


### PR DESCRIPTION
I tried clicking at least three separate project titles trying to get to their repos, forgetting they're not linked, so I thought I'd contribute a quick improvement if it's desired.

Cheers!