### PR TITLE
Fix broken link to HACKMIT 2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,19 +280,19 @@
 
         <div class="row">
             <div class="col-md-7">
-                <a href="https://github.com/techx/hackmit-splash-2020" target="_blank">
+                <a href="https://archive.hackmit.org/2020/" target="_blank">
                     <img class="img-responsive border" src="assets/splash-2020.png" alt="splash-2020">
                 </a>
             </div>
             <div class="col-md-5">
                 <h3 class="montserrat-bold-uppercase">
-                    <a class="project-link" target="_blank" href="https://github.com/techx/hackmit-splash-2020" target="_blank">
+                    <a class="project-link" target="_blank" href="https://archive.hackmit.org/2020/" target="_blank">
                         hackmit.org</a>
                 </h3>
                 <h4>The HackMIT splash site</h4>
                 <p>The HackMIT homepage, with code released under an MIT license and content/assets released under a CC BY-NC-ND
                     license.</p>
-                <a class="project-link" target="_blank" href="https://github.com/techx/hackmit-splash-2020">View Project</a>
+                <a class="project-link" target="_blank" href="https://archive.hackmit.org/2020/">View Project</a>
             </div>
         </div>
         


### PR DESCRIPTION
# Problem

Originally, the project link of HACKMIT 2020 was linked to https://github.com/techx/hackmit-splash-2020 but this leads to a 404 page:

![image](https://user-images.githubusercontent.com/19341857/183909329-de009109-03c4-4232-837a-ca4731deb025.png)

# What is this PR about?

So, it's now changed to https://archive.hackmit.org/2020/ in this PR:

![image](https://user-images.githubusercontent.com/19341857/183910673-736c0689-77b4-4c92-92a8-f14b17131685.png)

By the way, I figured `techx/hackmit-splash-2020` is a private repository, which is why I think https://github.com/techx/hackmit-splash-2020 gives me a 404 page. I was going to ask you guys to consider making the repository public, but then it would be too big of a change just to fix broken image links. So, the easiest solution to fix these broken links seems to be just using https://archive.hackmit.org/2020/ and that, of course, is what this PR does.